### PR TITLE
Replaced link to Vilnius Ruby community

### DIFF
--- a/.phrozn/layouts/default.twig
+++ b/.phrozn/layouts/default.twig
@@ -43,7 +43,7 @@
                         <li><a href="http://www.usergroups.lt/">Usergroups.lt</a></li>
                         <li><a href="http://www.kaunasphp.lt">Kaunas PHP</a></li>
                         <li><a href="http://www.vilniusjs.lt">Vilnius JS</a></li>
-                        <li><a href="http://workshops.emptydot.com">RoR Workshops</a></li>
+                        <li><a href="http://www.vilniusrb.lt">Vilnius Ruby</a></li>
                         <li><a href="http://www.gdg-vilnius.lt">GDG Vilnius</a></li>
                         <li><a href="http://www.vilnius-jug.lt/">Vilnius JUG</a></li>
                         <li><a href="http://dotnetgroup.lt">Lietuvos .net naudotojų grupė</a></li>


### PR DESCRIPTION
workshops.emptydot.com seems to be outdated - replaced with current link to Vilnius Ruby community