### PR TITLE
(0x25) Announce 0x25, archive 0x24

### DIFF
--- a/.phrozn/entries/archive.twig
+++ b/.phrozn/entries/archive.twig
@@ -3,6 +3,21 @@ layout: archive.twig
 pageName: archive
 
 events:
+    - name: "Susitikimas 0x24"
+      date: 2015-11-05 19:00
+      facebook: https://www.facebook.com/events/872060149544132/
+      ligtingTalks: true
+      masterTopic:
+      sponsor:
+        - name: Build Stuff
+          url: http://www.buildstuff.lt
+          logo: buildstuff.png
+      speakers:
+        - name: Žilvinas Kuusas
+          title: Baby Steps to Domain-Driven Design
+          linkedin: http://lt.linkedin.com/in/kuusas
+        - name: Mantas Klasavicius
+          title: Measure Everything, Not Anything
     - name: "CodeWeek edition"
       date: 2015-10-15 19:00
       facebook: https://www.facebook.com/events/1675344716034508/

--- a/.phrozn/entries/index.twig
+++ b/.phrozn/entries/index.twig
@@ -36,41 +36,16 @@ afterparty:
 #          description:
 #          linkedin: 
 events:
-    - name: "Susitikimas 0x24"
-      date: 2015-11-05 19:00
-      facebook: https://www.facebook.com/events/872060149544132/
+    - name: "Susitikimas 0x25"
+      date: 2015-12-03 19:00
+      facebook: https://www.facebook.com/events/192046447798267/
       ligtingTalks: true
-      masterTopic:
-      sponsor:
-        - name: Build Stuff
-          url: http://www.buildstuff.lt
-          logo: buildstuff.png
+      masterTopic: VilniusPHP 3-iasis gimtadienis
       speakers:
-        - name: Žilvinas Kuusas  
-          title: Baby Steps to Domain-Driven Design
-          linkedin: http://lt.linkedin.com/in/kuusas
-        - name: Mantas Klasavicius 
-          title: Measure Everything, Not Anything
-    - name: "CodeWeek edition"
-      date: 2015-10-15 19:00
-      facebook: https://www.facebook.com/events/1675344716034508/
-      masterTopic: Šiais metais vėl prisidėdami prie Europos programavimo savaitės iniciatyvos (CodeWeek.eu) rengiame meetupą orientuotą į pradedančiuosius PHP programuotuojus ar norinčius jais tapti.
-      sponsor:
-        - name: Build Stuff
-          url: http://www.buildstuff.lt
-          logo: buildstuff.png
-      speakers:
-        - name: Aurelijus Banelis
-          title: Išlipus iš vieno PHP failo
-          description: Kai jau pavyko parašyti pirmą programą su PHP, kur eiti toliau, kaip tapti PHP profesionalu? Dalinamasi praktine patirtimi, kas pasiteisino, nuo ko ir kodėl pradėti gilintis PHP pasaulyje.
-          linkedin: http://www.linkedin.com/in/aurelijusbanelis
-        - name: Gediminas Morkevičius
-          title: From zero to hero
-          linkedin: http://www.linkedin.com/pub/gediminas-morkevičius/9/b0/680
-        - name: Justas Butkus
-          title: Įrankių svarba, arba Aho, Weinberger ir Kernighan palikimas
-          linkedin: https://www.linkedin.com/in/justasbutkus
-        - name: Marijus Kilmanas 
-          title: Xdebug: What is it good for?
-          linkedin: http://www.linkedin.com/in/marijuskilmanas
+        - name: Sergej Kurakin
+          title: Kodėl aš skaitau pranešimus
+          linkedin: http://www.linkedin.com/in/sergejkurakin
+        - name: Osvaldas Grigas
+          title: Enemies of Agile Design
+          linkedin: https://lt.linkedin.com/in/ogrigas
 ---


### PR DESCRIPTION
Populated details for 0x25 from the Facebook event page.
Archived previous `event` definition.
Removed redundant `event` definition from the home page.