### PR TITLE
Add automatic commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+before_script:
+- git config user.name "Travis-CI"
+- git config user.email "builds@travis-ci.org"
+
+script:
+- set -e
+- git clone https://${github_username}:${github_token}@github.com/vilniusphp/vilniusphp.github.io.git
+- make
+- cp -r public_html/ vilniusphp.github.io
+- cd vilniusphp.github.io
+- git add .
+- git commit -m "Build new website version"
+- git push origin master


### PR DESCRIPTION
Added travis.ci build where on commit travis will automatically build htmls and commit them to https://github.com/vilniusphp/vilniusphp.github.io page.

To setup travis:
* Enable travis by going to https://travis-ci.org/  and enabling travis builds for https://github.com/vilniusphp/home repository.
* Create github access token
* Add environmental variables in travis builds. `github_token`, `github_username` should be configured.