### PR TITLE
Fix broken include for Lighting talks widget

### DIFF
--- a/.phrozn/layouts/widgets/event.twig
+++ b/.phrozn/layouts/widgets/event.twig
@@ -33,11 +33,6 @@
                 </div>
             </div>
         {% endfor %}
-        {% if event.ligtingTalks %}
-            <div class="col-md-4">
-                {% include 'layouts/widgets/lighting-talks.twig' %}
-            </div>
-        {% endif %}
     </div>
     <div class="col-sm-4">
         {% if event.sponsor %}


### PR DESCRIPTION
Widget was removed with https://github.com/vilniusphp/home/commit/a5919ac96d406aeaa55472e809260fc75d1f20f5
But in `Old talks` page it was still used.

Before fix on https://vilniusphp.lt/archive.html
![image](https://user-images.githubusercontent.com/1453957/81438112-e3a9a080-9174-11ea-90a5-d07df3161819.png)

After fix:
![image](https://user-images.githubusercontent.com/1453957/81438224-0b990400-9175-11ea-8e7d-f4a6d26b0eaf.png)
